### PR TITLE
Made adjustments to logic, added some listeners

### DIFF
--- a/maps/mp/gametypes/_gamelogic.gsc
+++ b/maps/mp/gametypes/_gamelogic.gsc
@@ -2,22 +2,22 @@
 #include maps\mp\gametypes\_hud_util;
 #include common_scripts\utility;
 
-FACTION_REF_COL                     = 0;
-FACTION_NAME_COL                     = 1;
-FACTION_SHORT_NAME_COL                 = 1;
-FACTION_WIN_GAME_COL                 = 3; 
-FACTION_WIN_ROUND_COL                 = 4;
-FACTION_MISSION_ACCOMPLISHED_COL     = 5;
-FACTION_ELIMINATED_COL                 = 6;
-FACTION_FORFEITED_COL                 = 7;
-FACTION_ICON_COL                     = 8;
-FACTION_HUD_ICON_COL                 = 9;
-FACTION_VOICE_PREFIX_COL             = 10;
-FACTION_SPAWN_MUSIC_COL             = 11;
-FACTION_WIN_MUSIC_COL                 = 12;
-FACTION_COLOR_R_COL                 = 13;
-FACTION_COLOR_G_COL                 = 14;
-FACTION_COLOR_B_COL                 = 15;
+FACTION_REF_COL = 0;
+FACTION_NAME_COL = 1;
+FACTION_SHORT_NAME_COL = 1;
+FACTION_WIN_GAME_COL = 3; 
+FACTION_WIN_ROUND_COL = 4;
+FACTION_MISSION_ACCOMPLISHED_COL = 5;
+FACTION_ELIMINATED_COL = 6;
+FACTION_FORFEITED_COL = 7;
+FACTION_ICON_COL = 8;
+FACTION_HUD_ICON_COL = 9;
+FACTION_VOICE_PREFIX_COL = 10;
+FACTION_SPAWN_MUSIC_COL = 11;
+FACTION_WIN_MUSIC_COL = 12;
+FACTION_COLOR_R_COL = 13;
+FACTION_COLOR_G_COL = 14;
+FACTION_COLOR_B_COL = 15;
 
 // when a team leaves completely, that team forfeited, team left wins round, ends game
 onForfeit( team )

--- a/maps/mp/tsd/_actionlisteners.gsc
+++ b/maps/mp/tsd/_actionlisteners.gsc
@@ -81,10 +81,8 @@ onWeaponFired()
             if (!bulletTracePassed(self getTagOrigin("j_head"), player getTagOrigin("j_head"), false, self))
                 continue;
 
-            if (hitAssist == 1 && distance(destination, player.origin) <= 100)
-                player thread [[level.callbackPlayerDamage]](self, self, 1000000, 8, "MOD_RIFLE_BULLET", self getCurrentWeapon(), (0, 0, 0), (0, 0, 0), "torso_upper", 0);
-            else if (hitAssist == 2)
-                player thread [[level.callbackPlayerDamage]](self, self, 1000000, 8, "MOD_RIFLE_BULLET", self getCurrentWeapon(), (0, 0, 0), (0, 0, 0), "torso_upper", 0);
+            if (distance(destination, player.origin) <= 125)
+                player thread [[level.callbackPlayerDamage]](self, self, 10000, 8, "MOD_RIFLE_BULLET", self getCurrentWeapon(), (0, 0, 0), (0, 0, 0), "torso_upper", 0);
         }
     }
 }

--- a/maps/mp/tsd/_gamelisteners.gsc
+++ b/maps/mp/tsd/_gamelisteners.gsc
@@ -1,0 +1,16 @@
+init()
+{
+    level thread onEndOfRound();
+}
+
+onEndOfRound()
+{
+    level endon("disconnect");
+
+    for(;;)
+    {
+        level waittill("round_win");
+
+        setDvar("timescale", 1);
+    }
+}

--- a/maps/mp/tsd/_initialize.gsc
+++ b/maps/mp/tsd/_initialize.gsc
@@ -12,6 +12,7 @@ Callback_TrickShotDummy()
     }
 
     setRoundSettings();
+    maps\mp\tsd\_gamelisteners::init();
     maps\mp\tsd\_players::init();
 }
 
@@ -60,8 +61,7 @@ initGameSettings()
     
     game["tsd"]["settings"]["hitassist"]["value"] = 0;
     game["tsd"]["settings"]["hitassist"]["options"][0]["text"] = "Off";
-    game["tsd"]["settings"]["hitassist"]["options"][1]["text"] = "Close To Enemy";
-    game["tsd"]["settings"]["hitassist"]["options"][2]["text"] = "Within Player FOV";
+    game["tsd"]["settings"]["hitassist"]["options"][1]["text"] = "On";
     
     game["tsd"]["settings"]["straightnoscopes"]["value"] = 0;
     game["tsd"]["settings"]["straightnoscopes"]["options"][0]["text"] = "Off";

--- a/maps/mp/tsd/_players.gsc
+++ b/maps/mp/tsd/_players.gsc
@@ -47,8 +47,6 @@ setGameVariables()
     if (self isHost() && !isDefined(game["tsd"]["admins"][self.guid]))
         game["tsd"]["admins"][self.guid] = true;
 
-    // self.pers["lives"] = 100000;
-
     self.pers["team"] = "axis";
     self allowSpectateTeam("axis", true);
 }

--- a/maps/mp/tsd/menu/_actionlisteners.gsc
+++ b/maps/mp/tsd/menu/_actionlisteners.gsc
@@ -55,6 +55,9 @@ onToggleMenu()
     {
         self waittill("toggle_menu");
         
+        if (!isAlive(self))
+            continue;
+
         if (self.tsd["menu"]["open"])
             self notify("menu_close");
         else


### PR DESCRIPTION
Generic
- Cleaned up _gamelogic a little
- Added _gamelisteners to detect game events
  - Added round_win listener to reset timescale to 1.

Player Changes
 - Opening the menu only works if the player is alive

Menu Content Changes
 - Hit assist is now only togglable (On/Off), distance is fixed to 125.